### PR TITLE
Add attributeIgnoreCase parameter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,12 @@ export const options: {
     type: "string",
     category: "Global",
     description:
-      "attributeSort HTML attribute grousp internally. ASC, DESC or NONE.",
+      "attributeSort HTML attribute groups internally. ASC, DESC or NONE.",
+  },
+  attributeIgnoreCase: {
+    type: "boolean",
+    category: "Global",
+    description: "A flag to ignore casing in regexps or not.",
   },
 };
 
@@ -58,6 +63,7 @@ function transformRootNode(
   const sort: OrganizeOptionsSort =
     options.attributeSort === "NONE" ? false : options.attributeSort;
   const groups = [...options.attributeGroups];
+  const ignoreCase = options.attributeIgnoreCase;
 
   if (groups.length === 0) {
     switch (options.parser.toString().toLowerCase()) {
@@ -73,18 +79,19 @@ function transformRootNode(
     }
   }
 
-  transformNode(node, groups, sort);
+  transformNode(node, groups, sort, ignoreCase);
   return node;
 }
 
 function transformNode(
   node: HTMLNode,
   groups: string[],
-  sort: OrganizeOptionsSort
+  sort: OrganizeOptionsSort,
+  ignoreCase = true
 ): void {
   if (node.attrs) {
     node.attrs = miniorganize(node.attrs, {
-      ignoreCase: true,
+      ignoreCase: ignoreCase,
       presets: PRESETS,
       groups,
       sort,
@@ -92,10 +99,13 @@ function transformNode(
     }).flat;
   }
 
-  node.children?.forEach((child) => transformNode(child, groups, sort));
+  node.children?.forEach((child) =>
+    transformNode(child, groups, sort, ignoreCase)
+  );
 }
 
 export type PrettierPluginOrganizeAttributesParserOptions = {
   attributeGroups: string[];
   attributeSort: "ASC" | "DESC" | "NONE";
+  attributeIgnoreCase: boolean;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,8 +91,8 @@ function transformNode(
 ): void {
   if (node.attrs) {
     node.attrs = miniorganize(node.attrs, {
-      ignoreCase: ignoreCase,
       presets: PRESETS,
+      ignoreCase,
       groups,
       sort,
       map: ({ name }) => name,

--- a/src/organize.spec.ts
+++ b/src/organize.spec.ts
@@ -1,6 +1,6 @@
 import { miniorganize, OrganizedGroup, DEFAULT_GROUP } from "./organize";
 
-fdescribe("miniorganize", () => {
+describe("miniorganize", () => {
   it("should miniorganize", () => {
     const input = ["c", "a1", "b1", "a2", "b2"];
     const expected = ["a1", "a2", "b1", "b2", "c"];

--- a/src/organize.spec.ts
+++ b/src/organize.spec.ts
@@ -1,6 +1,6 @@
 import { miniorganize, OrganizedGroup, DEFAULT_GROUP } from "./organize";
 
-describe("miniorganize", () => {
+fdescribe("miniorganize", () => {
   it("should miniorganize", () => {
     const input = ["c", "a1", "b1", "a2", "b2"];
     const expected = ["a1", "a2", "b1", "b2", "c"];
@@ -65,6 +65,32 @@ describe("miniorganize", () => {
     const result = miniorganize(input, {
       groups: ["^a", "^b"],
       sort: false,
+    }).flat;
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should ignore casing when ignoreCase is true", () => {
+    const input = ["attr1", "ATTR1", "attr2", "ATTR2"];
+    const expected = ["attr1", "ATTR1", "attr2", "ATTR2"];
+
+    const result = miniorganize(input, {
+      groups: ["^attr", "^ATTR"],
+      sort: false,
+      ignoreCase: true
+    }).flat;
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should NOT ignore casing when ignoreCase is false", () => {
+    const input = ["attr1", "ATTR1", "attr2", "ATTR2"];
+    const expected = ["attr1", "attr2", "ATTR1", "ATTR2"];
+
+    const result = miniorganize(input, {
+      groups: ["^attr", "^ATTR"],
+      sort: false,
+      ignoreCase: false
     }).flat;
 
     expect(result).toEqual(expected);


### PR DESCRIPTION
Hi, thanks for this package!

Closes #6 

What I want to achieve:
I'm an Angular developer and I'm trying to sort attributes in our application. One of the groups that I want to create is a group called VENDOR_DIRECTIVES. What it includes: in Angular (and in Vue I believe) you can use directives to modify nodes somehow. There is a lot of directives provided by the community and for Angular is Material library and CDK toolkit.
An example of usage of such directives:
```
<my-component
myInput <-- not a directive
cdkScrollable <-- a directive
></my-component
```

To correctly describe group for inputs but ignoring cdk* directives I use the following group:
```
"^((?!(cdk)[A-Z])[a-z])"
```
but since all regexps before this pr are case insensitive it becomes
```
/^((?!(cdk)[A-Z])[a-z])/i
```
and this is not what was expected, because it actually matches the same as `/cdk.*/`.
So I introduced an option to control `ignoreCase` from outside and added tests for it.