### PR TITLE
Add a means to ignore certain attributes when sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,36 @@ Read below for writing custom attribute orders and configurations ⤵️
 <div group-a group-b group-A group-B></div>
 ```
 
+---
+
+### Keep certain attributes in place
+
+You can prevent certain attributes from being moved altogether with `prettier-ignore-organize-attributes` comment:
+
+```json5
+// .prettierrc
+{
+  "plugins": ["prettier-plugin-organize-attributes"],
+  "attributeGroups": ["^a$", "^b$", "^c$", "^d$"]
+}
+```
+
+Input:
+
+```html
+<!-- prettier-ignore-organize-attributes a1 a2 a3 -->
+<div c="c" a1="1" d="d" a2="2" a="a" a3="3" b="b"></div>
+```
+
+*(Note that attributes should be space separated)*
+
+Output:
+
+```html
+<!-- prettier-ignore-organize-attributes a1 a2 a3 -->
+<div a="a" a1="1" b="b" a2="2" c="c" a3="3" d="d"></div>
+```
+
 ## Presets
 
 ### HTML

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "prettier-plugin-organize-attributes",
-  "version": "0.0.5",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prettier-plugin-organize-attributes",
-      "version": "0.0.5",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "29.1.1",
         "@types/node": "^14.14.2",
         "codecov": "^3.8.0",
+        "cross-env": "^7.0.3",
         "jest": "29.1.1",
         "prettier": "^3.0.0",
         "ts-jest": "29.1.1",
@@ -19,7 +20,7 @@
         "typescript": "^5.0.0"
       },
       "engines": {
-        "node": ">=11.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "prettier": "^3.0.0"
@@ -1540,6 +1541,24 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -5032,6 +5051,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
   "main": "lib/index",
   "types": "lib/index",
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --no-warnings\" jest",
+    "test:watch": "npm run test -- --watch",
     "build": "tsc --pretty",
     "watch": "npm run build -- --watch",
-    "watch:test": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
     "release:plugin": "npm run test && npm run build && npm publish",
     "release:plugin:local": "npm run test && npm run build && npm publish --registry=http://localhost:4873/"
   },
   "peerDependencies": {
     "prettier": "^3.0.0"
   },
-  "dependencies": {},
   "devDependencies": {
     "@types/jest": "29.1.1",
     "@types/node": "^14.14.2",
     "codecov": "^3.8.0",
+    "cross-env": "^7.0.3",
     "jest": "29.1.1",
     "prettier": "^3.0.0",
     "ts-jest": "29.1.1",

--- a/src/tests/html/ignore-attribute-basic/config.json
+++ b/src/tests/html/ignore-attribute-basic/config.json
@@ -1,0 +1,1 @@
+{"attributeGroups": ["^a$", "^b$", "^c$", "^d$"]}

--- a/src/tests/html/ignore-attribute-basic/expected.html
+++ b/src/tests/html/ignore-attribute-basic/expected.html
@@ -1,0 +1,2 @@
+<!-- prettier-ignore-organize-attributes a1 a2 a3 -->
+<div a="a" a1="1" b="b" a2="2" c="c" a3="3" d="d"></div>

--- a/src/tests/html/ignore-attribute-basic/input.html
+++ b/src/tests/html/ignore-attribute-basic/input.html
@@ -1,0 +1,10 @@
+<!-- prettier-ignore-organize-attributes a1 a2 a3 -->
+<div
+  c="c"
+  a1="1"
+  d="d"
+  a2="2"
+  a="a"
+  a3="3"
+  b="b"
+></div>

--- a/src/tests/html/ignore-attribute-comment-between/config.json
+++ b/src/tests/html/ignore-attribute-comment-between/config.json
@@ -1,0 +1,1 @@
+{"attributeGroups": ["^a$", "^b$", "^c$", "^d$"]}

--- a/src/tests/html/ignore-attribute-comment-between/expected.html
+++ b/src/tests/html/ignore-attribute-comment-between/expected.html
@@ -1,0 +1,3 @@
+<!-- prettier-ignore-organize-attributes a1 a2 a3 -->
+<!-- This comment should not affect the ignore directive -->
+<div a="a" a1="1" b="b" a2="2" c="c" a3="3" d="d"></div>

--- a/src/tests/html/ignore-attribute-comment-between/input.html
+++ b/src/tests/html/ignore-attribute-comment-between/input.html
@@ -1,0 +1,11 @@
+<!-- prettier-ignore-organize-attributes a1 a2 a3 -->
+<!-- This comment should not affect the ignore directive -->
+<div
+  c="c"
+  a1="1"
+  d="d"
+  a2="2"
+  a="a"
+  a3="3"
+  b="b"
+></div>

--- a/src/tests/html/ignore-attribute-empty-lines-between/config.json
+++ b/src/tests/html/ignore-attribute-empty-lines-between/config.json
@@ -1,0 +1,1 @@
+{"attributeGroups": ["^a$", "^b$", "^c$", "^d$"]}

--- a/src/tests/html/ignore-attribute-empty-lines-between/expected.html
+++ b/src/tests/html/ignore-attribute-empty-lines-between/expected.html
@@ -1,0 +1,3 @@
+<!-- prettier-ignore-organize-attributes a1 a2 a3 -->
+
+<div a="a" a1="1" b="b" a2="2" c="c" a3="3" d="d"></div>

--- a/src/tests/html/ignore-attribute-empty-lines-between/input.html
+++ b/src/tests/html/ignore-attribute-empty-lines-between/input.html
@@ -1,0 +1,15 @@
+<!-- prettier-ignore-organize-attributes a1 a2 a3 -->
+
+
+
+
+
+<div
+  c="c"
+  a1="1"
+  d="d"
+  a2="2"
+  a="a"
+  a3="3"
+  b="b"
+></div>

--- a/src/tests/html/ignore-attribute-multiple/config.json
+++ b/src/tests/html/ignore-attribute-multiple/config.json
@@ -1,0 +1,1 @@
+{"attributeGroups": ["^a$", "^b$", "^c$", "^d$"]}

--- a/src/tests/html/ignore-attribute-multiple/expected.html
+++ b/src/tests/html/ignore-attribute-multiple/expected.html
@@ -1,0 +1,3 @@
+<!-- prettier-ignore-organize-attributes a1 a2 a3 -->
+<!-- prettier-ignore-organize-attributes c -->
+<div c="c" a="a" b="b" d="d" a1="1" a2="2" a3="3"></div>

--- a/src/tests/html/ignore-attribute-multiple/input.html
+++ b/src/tests/html/ignore-attribute-multiple/input.html
@@ -1,0 +1,11 @@
+<!-- prettier-ignore-organize-attributes a1 a2 a3 -->
+<!-- prettier-ignore-organize-attributes c -->
+<div
+  c="c"
+  a1="1"
+  d="d"
+  a2="2"
+  a="a"
+  a3="3"
+  b="b"
+></div>

--- a/src/tests/html/ignore-attribute-text-between/config.json
+++ b/src/tests/html/ignore-attribute-text-between/config.json
@@ -1,0 +1,1 @@
+{"attributeGroups": ["^a$", "^b$", "^c$", "^d$"]}

--- a/src/tests/html/ignore-attribute-text-between/expected.html
+++ b/src/tests/html/ignore-attribute-text-between/expected.html
@@ -1,0 +1,3 @@
+<!-- prettier-ignore-organize-attributes a1 a2 a3 -->
+This text will negate the ignore directive
+<div a="a" b="b" c="c" d="d" a1="1" a2="2" a3="3"></div>

--- a/src/tests/html/ignore-attribute-text-between/input.html
+++ b/src/tests/html/ignore-attribute-text-between/input.html
@@ -1,0 +1,11 @@
+<!-- prettier-ignore-organize-attributes a1 a2 a3 -->
+This text will negate the ignore directive
+<div
+  c="c"
+  a1="1"
+  d="d"
+  a2="2"
+  a="a"
+  a3="3"
+  b="b"
+></div>

--- a/src/tests/vue/ignore-attribute-basic/config.json
+++ b/src/tests/vue/ignore-attribute-basic/config.json
@@ -1,0 +1,1 @@
+{"attributeGroups": ["^a$", "^b$", "^c$", "^d$"]}

--- a/src/tests/vue/ignore-attribute-basic/expected.vue
+++ b/src/tests/vue/ignore-attribute-basic/expected.vue
@@ -1,0 +1,4 @@
+<template>
+  <!-- prettier-ignore-organize-attributes a1 a2 a3 -->
+  <div a="a" a1="1" b="b" a2="2" c="c" a3="3" d="d"></div>
+</template>

--- a/src/tests/vue/ignore-attribute-basic/input.vue
+++ b/src/tests/vue/ignore-attribute-basic/input.vue
@@ -1,0 +1,12 @@
+<template>
+  <!-- prettier-ignore-organize-attributes a1 a2 a3 -->
+  <div
+    c="c"
+    a1="1"
+    d="d"
+    a2="2"
+    a="a"
+    a3="3"
+    b="b"
+  ></div>
+</template>


### PR DESCRIPTION
Sometimes it's needed to keep an attribute in place, for example in Vue 3, [where `v-bind` position matters](https://v3-migration.vuejs.org/breaking-changes/v-bind.html#_3-x-syntax).

This PR adds a means to prevent certain attributes from being moved with `prettier-ignore-organize-attributes` comment (see README for a usage example).